### PR TITLE
Get away from master-slave jargon

### DIFF
--- a/Server.py
+++ b/Server.py
@@ -78,25 +78,25 @@ def reply(msg):
 # RS485-Modbus通讯
 def Modbus_485(PORT,Regist_Address,Regist_Number):
     try:
-        #Connect to the slave
-        master = modbus_rtu.RtuMaster(
+        #Connect to the subordinate
+        main = modbus_rtu.RtuMain(
             serial.Serial(port=PORT, baudrate=9600, bytesize=8, parity='N', stopbits=1, xonxoff=0)
         )
-        master.set_timeout(5.0)
-        master.set_verbose(True)
+        main.set_timeout(5.0)
+        main.set_verbose(True)
         print("%s  connected"% datetime.now())
  
-        return(master.execute(1, cst.READ_HOLDING_REGISTERS, Regist_Address, Regist_Number))
+        return(main.execute(1, cst.READ_HOLDING_REGISTERS, Regist_Address, Regist_Number))
  
         #send some queries
-        #logger.info(master.execute(1, cst.READ_COILS, 0, 10))
-        #logger.info(master.execute(1, cst.READ_DISCRETE_INPUTS, 0, 8))
-        #logger.info(master.execute(1, cst.READ_INPUT_REGISTERS, 0, 10))
-        #logger.info(master.execute(1, cst.READ_HOLDING_REGISTERS, 100, 12))
-        #logger.info(master.execute(1, cst.WRITE_SINGLE_COIL, 7, output_value=1))
-        #logger.info(master.execute(1, cst.WRITE_SINGLE_REGISTER, 100, output_value=54))
-        #logger.info(master.execute(1, cst.WRITE_MULTIPLE_COILS, 0, output_value=[1, 1, 0, 1, 1, 0, 1, 1]))
-        #logger.info(master.execute(1, cst.WRITE_MULTIPLE_REGISTERS, 100, output_value=xrange(12)))
+        #logger.info(main.execute(1, cst.READ_COILS, 0, 10))
+        #logger.info(main.execute(1, cst.READ_DISCRETE_INPUTS, 0, 8))
+        #logger.info(main.execute(1, cst.READ_INPUT_REGISTERS, 0, 10))
+        #logger.info(main.execute(1, cst.READ_HOLDING_REGISTERS, 100, 12))
+        #logger.info(main.execute(1, cst.WRITE_SINGLE_COIL, 7, output_value=1))
+        #logger.info(main.execute(1, cst.WRITE_SINGLE_REGISTER, 100, output_value=54))
+        #logger.info(main.execute(1, cst.WRITE_MULTIPLE_COILS, 0, output_value=[1, 1, 0, 1, 1, 0, 1, 1]))
+        #logger.info(main.execute(1, cst.WRITE_MULTIPLE_REGISTERS, 100, output_value=xrange(12)))
  
     except modbus_tk.modbus.ModbusError as exc:
         print("%s- Code=%d", exc, exc.get_exception_code())


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.